### PR TITLE
chore: add semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,13 @@ node_js:
 before_script:
   npm run build
 after_success:
-  npm run lint
+  - npm run lint
+  - curl -Lo travis_after_all.py https://git.io/travis_after_all
+  - python travis_after_all.py
+  - export $(cat .to_export_back)
+  - |
+      if [ "$BUILD_LEADER" = "YES" ]; then
+        if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+          npm run semantic-release
+        fi
+      fi

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "react-drawer",
-  "version": "1.2.3",
   "description": "react drawer menu",
   "main": "./lib/react-drawer.js",
   "scripts": {
     "dev": "webpack-dev-server",
     "build": "webpack",
     "lint": "./node_modules/.bin/eslint src/",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
@@ -49,6 +49,7 @@
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
     "sass-loader": "^4.0.0",
+    "semantic-release": "^4.3.5",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.11",


### PR DESCRIPTION
as mentionned in #9 here is the corresponding change.

* add semantic release dependecy in package.json
* add semantic-release npm script in package.json
* update travis yml to call npm run semantic-release

The travis.yml use travis_after_all.py because of the matrix node 4 and 6. we have to launch this script only once

More documentation on that https://github.com/dmakhno/travis_after_all
