### PR TITLE
docs: add contributing + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+**Please check if the PR fulfills these requirements**
+
+- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+**What is the current behavior?** (You can also link to an open issue here)
+
+
+
+**What is the new behavior?**
+
+
+
+**Does this PR introduce a breaking change?**
+
+- [ ] Yes
+- [ ] No
+
+If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
+
+
+**Other information**:
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to the project
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+Here are the guidelines we'd like you to follow:
+
+- [Pull Requests](#pullrequest)
+- [Commit Message Guidelines](#commit)
+
+## <a name="pullrequest"></a> Github Pull Requests
+
+QA: Quality Assurance
+PR: Pull Request
+CI: Continuous Integration (Travis)
+
+Here is the workflow for pull requests we are using.
+
+1. Submit your pull request.
+   => the CI should kick tests so you will have feedback about the different QA
+2. If any issues are marked on the PR by CI please fix them. No broken PR will be reviewed.
+3. Once the quality checks are OK, and you need your PR to be reviewed you must use the label **Need review**. If your PR is still a work in progress, do not use any label but this means no review will be performed.
+4. The components owners will then identify who is going to do the review and then assign it. The reviewer will recieve an automatic mail notification.
+5. Once the reviewer starts the review, he/she should set the label **Reviewing**.
+6. We use the new review system of github so you will know if the reviewer request changes, approve it or just add some comments.
+7. if any changes are requested please fix them and then once you are ready request a new review by ping the reviewer throw github
+
+## <a name="commit"></a> Git Commit Guidelines
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**.
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+#### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+#### Type
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
+
+#### Scope
+The scope could be anything specifying place of the commit change. Most of the time it shoulb be Jira ticket reference followed by a usefull context.
+
+For example `css`, `animation`, `example`, etc...
+
+#### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+#### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+#### Footer
+The footer should contain
+
+* any information about **Breaking Changes**
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+


### PR DESCRIPTION
This is to help people who want to contribute to the project.

Because we now use semantic release people has to follow contribution guidelines.

This is always better to have documentation !