### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Example
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactDrawer from 'react-drawer';
-
-/* if you using webpack, should not apply identity to this css */
 import 'react-drawer/lib/react-drawer.css';
 
 class Main extends React.Component {

--- a/src/ReactDrawer.js
+++ b/src/ReactDrawer.js
@@ -32,8 +32,8 @@ class ReactDrawer extends React.Component {
   componentWillMount() {
     this.setState({
       open: this.props.open,
-      hiddenOverlay: true,
-      hiddenDrawer: true
+      hiddenOverlay: !this.props.open,
+      hiddenDrawer: !this.props.open
     });
   }
 

--- a/src/ReactDrawer.test.js
+++ b/src/ReactDrawer.test.js
@@ -41,13 +41,15 @@ describe('ReactDrawer', () => {
     );
     let instance = wrapper.instance();
     expect(instance.state.open).toBe(false);
+    expect(instance.state.hiddenOverlay).toBe(true);
+    expect(instance.state.hiddenDrawer).toBe(true);
     wrapper = mount(
       <ReactDrawer open />
     );
     instance = wrapper.instance();
     expect(instance.state.open).toBe(true);
-    expect(instance.state.hiddenOverlay).toBe(true);
-    expect(instance.state.hiddenDrawer).toBe(true);
+    expect(instance.state.hiddenOverlay).toBe(false);
+    expect(instance.state.hiddenDrawer).toBe(false);
   });
 
   it('should closeDrawer set some state', () => {
@@ -145,11 +147,11 @@ describe('ReactDrawer', () => {
     );
     const instance = wrapper.instance();
     let c = instance.getOverlayClassName(theme, animate).split(' ');
-    expect(c.length).toBe(4);
+    expect(c.length).toBe(3);
     expect(c.indexOf('react-drawer-overlay')).not.toBe(-1);
     expect(c.indexOf('test-overlay')).not.toBe(-1);
     expect(c.indexOf('test-fadeIn')).not.toBe(-1);
-    expect(c.indexOf('test-hidden')).not.toBe(-1);
+    expect(c.indexOf('test-hidden')).toBe(-1);
 
     instance.state.open = false;
     c = instance.getOverlayClassName(theme, animate).split(' ');
@@ -185,10 +187,10 @@ describe('ReactDrawer', () => {
     );
     let instance = wrapper.instance();
     let c = instance.getDrawerClassName(theme, animate).split(' ');
-    expect(c.length).toBe(5);
+    expect(c.length).toBe(4);
     expect(c.indexOf('react-drawer-drawer')).not.toBe(-1);
     expect(c.indexOf('test-drawer')).not.toBe(-1);
-    expect(c.indexOf('test-hidden')).not.toBe(-1);
+    expect(c.indexOf('test-hidden')).toBe(-1);
     expect(c.indexOf('test-fadeInUp')).toBe(-1);
     expect(c.indexOf('test-fadeInRight')).not.toBe(-1);
     expect(c.indexOf('test-fadeInDown')).toBe(-1);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) - I found this a bit complicated, but I think I meet the minimum requirements
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - I don't think any doc change is required


**What is the current behavior?** (You can also link to an open issue here)
When startOpen is true the drawer does not show since the hiddenOverlay and hiddenDrawer states are also set to true.


**What is the new behavior?**
hiddenOverlay and hiddenDrawer are set to the inverse of startOpen, which means that the drawer is visible when startOpen is set to true


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

